### PR TITLE
Improve WebID mention support in Long Chat pane

### DIFF
--- a/src/longChatPane.js
+++ b/src/longChatPane.js
@@ -749,13 +749,15 @@ function renderMessageContent(dom, content) {
   const tokens = []
   let lastIndex = 0
 
-  content.replace(MENTION_RE, (match, bracedWebId, plainWebId, index) => {
-    const webId = bracedWebId || plainWebId  // Use whichever captured
-    if (index > lastIndex) {
-      tokens.push({ type: 'text', value: content.slice(lastIndex, index) })
+  content.replace(MENTION_RE, (match, bracedWebId, plainWebId, offset) => {
+    const webId = bracedWebId || plainWebId
+
+    if (offset > lastIndex) {
+      tokens.push({ type: 'text', value: content.slice(lastIndex, offset) })
     }
+
     tokens.push({ type: 'mention', webId })
-    lastIndex = index + match.length
+    lastIndex = offset + match.length
   })
 
   if (lastIndex < content.length) {

--- a/src/longChatPane.js
+++ b/src/longChatPane.js
@@ -836,8 +836,8 @@ function renderMessageContent(dom, content) {
         span.innerHTML = parseMarkdown(part)
         container.appendChild(span)
       }
+    }
   }
-
   return container
 }
 

--- a/src/longChatPane.js
+++ b/src/longChatPane.js
@@ -784,57 +784,47 @@ function renderMessageContent(dom, content) {
       if (URL_REGEX.test(part)) {
         URL_REGEX.lastIndex = 0
 
-        // Image
-        if (IMAGE_EXT.test(part)) {
-          const wrapper = dom.createElement('div')
-          wrapper.className = 'media-wrapper'
+      // Image
+      if (IMAGE_EXT.test(part)) {
+        const wrapper = dom.createElement('div')
+        wrapper.className = 'media-wrapper'
 
-          const img = dom.createElement('img')
-          img.src = part
-          img.alt = 'Image'
-          img.loading = 'lazy'
-          img.onclick = () => window.open(part, '_blank')
-          img.onload = () => {
-            const mc = wrapper.closest('.messages-container')
-            if (mc) mc.scrollTop = mc.scrollHeight
-          }
-
-          wrapper.appendChild(img)
-          container.appendChild(wrapper)
-
-        // Video
-        } else if (VIDEO_EXT.test(part)) {
-          const wrapper = dom.createElement('div')
-          wrapper.className = 'media-wrapper'
-          const video = dom.createElement('video')
-          video.src = part
-          video.controls = true
-          video.preload = 'metadata'
-          wrapper.appendChild(video)
-          container.appendChild(wrapper)
-
-        // Audio
-        } else if (AUDIO_EXT.test(part)) {
-          const wrapper = dom.createElement('div')
-          wrapper.className = 'media-wrapper'
-          const audio = dom.createElement('audio')
-          audio.src = part
-          audio.controls = true
-          audio.preload = 'metadata'
-          wrapper.appendChild(audio)
-          container.appendChild(wrapper)
-
-        // Regular link
-        } else {
-          const link = dom.createElement('a')
-          link.href = part
-          link.textContent = part.length > 50 ? part.slice(0, 50) + '...' : part
-          link.target = '_blank'
-          link.rel = 'noopener noreferrer'
-          container.appendChild(link)
+        const img = dom.createElement('img')
+        img.src = part
+        img.alt = 'Image'
+        img.loading = 'lazy'
+        img.onclick = () => window.open(part, '_blank')
+        img.onload = () => {
+          const mc = wrapper.closest('.messages-container')
+          if (mc) mc.scrollTop = mc.scrollHeight
         }
 
-      // Regular text (markdown)
+        wrapper.appendChild(img)
+        container.appendChild(wrapper)
+
+      // Video
+      } else if (VIDEO_EXT.test(part)) {
+        const wrapper = dom.createElement('div')
+        wrapper.className = 'media-wrapper'
+        const video = dom.createElement('video')
+        video.src = part
+        video.controls = true
+        video.preload = 'metadata'
+        wrapper.appendChild(video)
+        container.appendChild(wrapper)
+
+      // Audio
+      } else if (AUDIO_EXT.test(part)) {
+        const wrapper = dom.createElement('div')
+        wrapper.className = 'media-wrapper'
+        const audio = dom.createElement('audio')
+        audio.src = part
+        audio.controls = true
+        audio.preload = 'metadata'
+        wrapper.appendChild(audio)
+        container.appendChild(wrapper)
+
+        // Regular link
       } else if (part) {
         const span = dom.createElement('span')
         span.innerHTML = parseMarkdown(part)

--- a/src/longChatPane.js
+++ b/src/longChatPane.js
@@ -24,7 +24,6 @@ const FLOW = {
   Message: 'http://www.w3.org/2005/01/wf/flow#Message'
 }
 
-// Matches @{webId} or @https://... (without braces)
 const MENTION_RE = /@\{([^}]+)\}|@(https?:\/\/[^\s]+)/g
 const MENTION_TRIGGER = /@([^\s@{]*)$/
 let mentionIndex = -1

--- a/src/longChatPane.js
+++ b/src/longChatPane.js
@@ -784,53 +784,60 @@ function renderMessageContent(dom, content) {
       if (URL_REGEX.test(part)) {
         URL_REGEX.lastIndex = 0
 
-      // Image
-      if (IMAGE_EXT.test(part)) {
-        const wrapper = dom.createElement('div')
-        wrapper.className = 'media-wrapper'
+        // Image
+        if (IMAGE_EXT.test(part)) {
+          const wrapper = dom.createElement('div')
+          wrapper.className = 'media-wrapper'
 
-        const img = dom.createElement('img')
-        img.src = part
-        img.alt = 'Image'
-        img.loading = 'lazy'
-        img.onclick = () => window.open(part, '_blank')
-        img.onload = () => {
-          const mc = wrapper.closest('.messages-container')
-          if (mc) mc.scrollTop = mc.scrollHeight
+          const img = dom.createElement('img')
+          img.src = part
+          img.alt = 'Image'
+          img.loading = 'lazy'
+          img.onclick = () => window.open(part, '_blank')
+          img.onload = () => {
+            const mc = wrapper.closest('.messages-container')
+            if (mc) mc.scrollTop = mc.scrollHeight
+          }
+
+          wrapper.appendChild(img)
+          container.appendChild(wrapper)
+
+        // Video
+        } else if (VIDEO_EXT.test(part)) {
+          const wrapper = dom.createElement('div')
+          wrapper.className = 'media-wrapper'
+          const video = dom.createElement('video')
+          video.src = part
+          video.controls = true
+          video.preload = 'metadata'
+          wrapper.appendChild(video)
+          container.appendChild(wrapper)
+
+        // Audio
+        } else if (AUDIO_EXT.test(part)) {
+          const wrapper = dom.createElement('div')
+          wrapper.className = 'media-wrapper'
+          const audio = dom.createElement('audio')
+          audio.src = part
+          audio.controls = true
+          audio.preload = 'metadata'
+          wrapper.appendChild(audio)
+          container.appendChild(wrapper)
+
+        // ✅ Regular link (DEN SOM MANGLER NÅ)
+        } else {
+          const link = dom.createElement('a')
+          link.href = part
+          link.textContent = part.length > 50 ? part.slice(0, 50) + '...' : part
+          link.target = '_blank'
+          link.rel = 'noopener noreferrer'
+          container.appendChild(link)
         }
-
-        wrapper.appendChild(img)
-        container.appendChild(wrapper)
-
-      // Video
-      } else if (VIDEO_EXT.test(part)) {
-        const wrapper = dom.createElement('div')
-        wrapper.className = 'media-wrapper'
-        const video = dom.createElement('video')
-        video.src = part
-        video.controls = true
-        video.preload = 'metadata'
-        wrapper.appendChild(video)
-        container.appendChild(wrapper)
-
-      // Audio
-      } else if (AUDIO_EXT.test(part)) {
-        const wrapper = dom.createElement('div')
-        wrapper.className = 'media-wrapper'
-        const audio = dom.createElement('audio')
-        audio.src = part
-        audio.controls = true
-        audio.preload = 'metadata'
-        wrapper.appendChild(audio)
-        container.appendChild(wrapper)
-
-        // Regular link
       } else if (part) {
         const span = dom.createElement('span')
         span.innerHTML = parseMarkdown(part)
         container.appendChild(span)
       }
-    }
   }
 
   return container

--- a/src/longChatPane.js
+++ b/src/longChatPane.js
@@ -741,7 +741,6 @@ function parseMarkdown(text) {
   return html
 }
 
-// Render message content with links and media
 function renderMessageContent(dom, content) {
   const container = dom.createElement('div')
 
@@ -1070,6 +1069,7 @@ export const longChatPane = {
 
   render: function(subject, context, options) {
     let mentionStartIndex = null
+    let mentionsInDraft = []
     const dom = context.dom
     const store = context.session.store
     const $rdf = store.rdflib || globalThis.$rdf
@@ -1269,6 +1269,7 @@ export const longChatPane = {
     fileInput.onchange = async () => {
       const file = fileInput.files[0]
       if (file) await uploadFile(file)
+      mentionsInDraft.length = 0
       fileInput.value = ''
     }
 
@@ -1313,13 +1314,36 @@ export const longChatPane = {
       const before = value.slice(0, mentionStartIndex)
       const after = value.slice(caret)
 
-      input.value = `${before}@{${person.webId}} ${after}`
+      input.value = `${before}@${person.name} ${after}`
+
+      mentionsInDraft.push({
+        start: before.length,
+        text: `@${person.name}`,
+        webId: person.webId
+      })
       input.focus()
 
       mentionPopup.style.display = 'none'
       mentionStartIndex = null
 
       sendBtn.disabled = !input.value.trim()
+    }
+
+    function serializeMentions(text) {
+      if (!mentionsInDraft.length) return text
+
+      let out = text
+
+      mentionsInDraft
+        .sort((a, b) => b.start - a.start)
+        .forEach(m => {
+          const before = out.slice(0, m.start)
+          const after  = out.slice(m.start + m.text.length)
+
+          out = before + `@{${m.webId}}` + after
+        })
+
+      return out
     }
 
     const inputWrapper = dom.createElement('div')
@@ -1492,7 +1516,7 @@ export const longChatPane = {
 
           const updateQuery = `
             DELETE { <${msgUri}> <${SIOC('content').value}> ?content }
-            INSERT { <${msgUri}> <${SIOC('content').value}> ${JSON.stringify(newContent)} }
+            INSERT { <${msgUri}> <${SIOC('content').value}> "${newContent.replace(/"/g, '\\"')}" }
             WHERE { <${msgUri}> <${SIOC('content').value}> ?content }
           `
 
@@ -1818,8 +1842,11 @@ export const longChatPane = {
 
     // Send message
     async function sendMessage() {
-      const text = input.value.trim()
-      if (!text) return
+      const rawText = input.value.trim()
+      if (!rawText) return
+
+      // 🔑 HER – rett etter trim
+      const text = serializeMentions(rawText)
 
       sendBtn.disabled = true
       input.disabled = true
@@ -1836,12 +1863,13 @@ export const longChatPane = {
         const msgId = `#msg-${Date.now()}`
         const msgNode = $rdf.sym(subject.uri + msgId)
         const now = new Date().toISOString()
-        const mentionedWebIds = [...text.matchAll(MENTION_RE)].map(m => m[1] || m[2])
+
+        const mentionedWebIds = [...text.matchAll(MENTION_RE)].map(m => m[1] || m[2]).filter(Boolean)
 
         const ins = [
           $rdf.st(subject, FLOW('message'), msgNode, subject.doc()),
           $rdf.st(msgNode, RDF('type'), FLOW('Message'), subject.doc()),
-          $rdf.st(msgNode, SIOC('content'), text, subject.doc()),
+          $rdf.st(msgNode, SIOC('content'), $rdf.lit(text), subject.doc()),
           $rdf.st(msgNode, DCT('created'), $rdf.lit(now, null, $rdf.sym('http://www.w3.org/2001/XMLSchema#dateTime')), subject.doc())
         ]
 
@@ -1884,6 +1912,10 @@ export const longChatPane = {
         messages.push(msg)
         statusEl.textContent = `${messages.length} messages`
 
+        console.log('RAW:', rawText)
+        console.log('SER:', text)
+
+        mentionsInDraft.length = 0
         input.value = ''
         input.style.height = 'auto'
 


### PR DESCRIPTION
This change improves WebID mention handling in the Long Chat pane.

Added reliable support for mentioning users via WebID
Ensured mentions are correctly serialized and rendered in messages
Preserved surrounding message text when mentions are present
Improved robustness when extracting mentioned WebIDs
These improvements make mentions more predictable, readable, and usable across chat participants.